### PR TITLE
feat: swagger 추가 및 기본 설정

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@nestjs/typeorm": "^10.0.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
+    "express-basic-auth": "^1.2.1",
     "pg": "^8.13.1",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       class-validator:
         specifier: ^0.14.1
         version: 0.14.1
+      express-basic-auth:
+        specifier: ^1.2.1
+        version: 1.2.1
       pg:
         specifier: ^8.13.1
         version: 8.13.1
@@ -954,6 +957,10 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
+  basic-auth@2.0.1:
+    resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
+    engines: {node: '>= 0.8'}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -1427,6 +1434,9 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  express-basic-auth@1.2.1:
+    resolution: {integrity: sha512-L6YQ1wQ/mNjVLAmK3AG1RK6VkokA1BIY6wmiH304Xtt/cLTps40EusZsU1Uop+v9lTDPxdtzbFmdXfFO3KEnwA==}
 
   express@4.21.1:
     resolution: {integrity: sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==}
@@ -4078,6 +4088,10 @@ snapshots:
 
   base64-js@1.5.1: {}
 
+  basic-auth@2.0.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   binary-extensions@2.3.0: {}
 
   bl@4.1.0:
@@ -4551,6 +4565,10 @@ snapshots:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+
+  express-basic-auth@1.2.1:
+    dependencies:
+      basic-auth: 2.0.1
 
   express@4.21.1:
     dependencies:

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { DataSourceOptions } from 'typeorm';
 import { ConfigModule } from '@nestjs/config';
 import appConfig from './config/app.config';
 import postgresConfig from './database/config/postgres.config';
+import swaggerConfig from './config/swagger.config';
 
 const logger = new Logger('DatabaseConnection');
 logger.log(process.env.NODE_ENV);
@@ -27,7 +28,7 @@ const PostgresModule = TypeOrmModule.forRootAsync({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [appConfig, postgresConfig],
+      load: [appConfig, postgresConfig, swaggerConfig],
       envFilePath: `.env.${process.env.NODE_ENV}`,
     }),
     PostgresModule,

--- a/src/common/decorator/swagger.decorator.ts
+++ b/src/common/decorator/swagger.decorator.ts
@@ -1,0 +1,23 @@
+import { applyDecorators, Type } from '@nestjs/common';
+import { ApiCreatedResponse, ApiOkResponse } from '@nestjs/swagger';
+import { getSchemaPath } from '@nestjs/swagger';
+
+export const ApiGetResponse = <TModel extends Type<any>>(model: TModel) => {
+  return applyDecorators(
+    ApiOkResponse({
+      schema: {
+        allOf: [{ $ref: getSchemaPath(model) }],
+      },
+    }),
+  );
+};
+
+export const ApiPostResponse = <TModel extends Type<any>>(model: TModel) => {
+  return applyDecorators(
+    ApiCreatedResponse({
+      schema: {
+        allOf: [{ $ref: getSchemaPath(model) }],
+      },
+    }),
+  );
+};

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -6,7 +6,7 @@ import { AppConfig } from './app-config';
 enum Environment {
   Development = 'development',
   Production = 'production',
-  Test = 'test',
+  Local = 'local',
 }
 
 class EnvironmentVariablesValidator {

--- a/src/config/swagger.config.ts
+++ b/src/config/swagger.config.ts
@@ -1,0 +1,8 @@
+import { registerAs } from '@nestjs/config';
+
+export default registerAs('swagger', async () => {
+  return {
+    user: process.env.SWAGGER_USER || 'admin',
+    password: process.env.SWAGGER_PASSWORD || 'admin',
+  };
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,43 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
-
+import { DocumentBuilder } from '@nestjs/swagger';
+import { SwaggerModule } from '@nestjs/swagger';
+import { SwaggerCustomOptions } from '@nestjs/swagger';
+import { ConfigService } from '@nestjs/config';
+import * as expressBasicAuth from 'express-basic-auth';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const configService = app.get(ConfigService);
+
+  const SWAGGER_ENVS = ['local', 'development'];
+  const stage = configService.get('app.nodeEnv');
+  if (SWAGGER_ENVS.includes(stage)) {
+    app.use(
+      ['/docs', '/docs-json'],
+      expressBasicAuth({
+        challenge: true,
+        users: {
+          [configService.get('swagger.user')]:
+            configService.get('swagger.password'),
+        },
+      }),
+    );
+    const config = new DocumentBuilder()
+      .setTitle('NestJS project')
+      .setDescription('NestJS project API description')
+      .setVersion('1.0')
+      .addBearerAuth()
+      .build();
+    const customOptions: SwaggerCustomOptions = {
+      swaggerOptions: {
+        // TODO : 인증 구현 후 true로 변경
+        persistAuthorization: false,
+      },
+    };
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('docs', app, document, customOptions);
+  }
   await app.listen(process.env.PORT ?? 3000);
   console.log(`STAGE: ${process.env.NODE_ENV}`);
 }

--- a/src/modules/user/dto/req.dto.ts
+++ b/src/modules/user/dto/req.dto.ts
@@ -1,0 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsUUID } from 'class-validator';
+
+export class FindUserReqDto {
+  @ApiProperty({ required: true })
+  @IsUUID()
+  id: string;
+}

--- a/src/modules/user/dto/res.dto.ts
+++ b/src/modules/user/dto/res.dto.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FindUserResDto {
+  @ApiProperty({ required: true })
+  id: string;
+
+  @ApiProperty({ required: true })
+  email: string;
+
+  @ApiProperty({ required: true })
+  createdAt: string;
+}

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -1,8 +1,12 @@
-import { Controller, Get } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Param } from '@nestjs/common';
+import { ApiExtraModels, ApiTags } from '@nestjs/swagger';
 import { UserService } from './user.service';
+import { FindUserReqDto } from './dto/req.dto';
+import { ApiGetResponse } from 'src/common/decorator/swagger.decorator';
+import { FindUserResDto } from './dto/res.dto';
 
 @ApiTags('User')
+@ApiExtraModels(FindUserReqDto, FindUserResDto)
 @Controller('users')
 export class UserController {
   constructor(private readonly userService: UserService) {}
@@ -10,5 +14,11 @@ export class UserController {
   @Get()
   async getUsers() {
     return await this.userService.findAll();
+  }
+
+  @ApiGetResponse(FindUserResDto)
+  @Get(':id')
+  async findOne(@Param('id') { id }: FindUserReqDto) {
+    return await this.userService.findOne(id);
   }
 }

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -5,4 +5,8 @@ export class UserService {
   async findAll() {
     return 'findAll';
   }
+
+  async findOne(id: string) {
+    return `findOne: ${id}`;
+  }
 }


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
Swagger 설정 및 User API 테스트 엔드포인트 추가
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- @nestjs/swagger, swagger-ui-express 의존성 추가
- Swagger 모듈을 사용하여 API 문서 페이지를 설정 `localhost:3000/docs`
- Swagger 응답 데코레이터 추가
- Swagger 인증 설정 추가
   - Swagger UI에서 인증이 필요한 API를 테스트할 수 있도록 인증 설정을 추가
   - 사용자는 UI 상에서 토큰을 입력하여 인증된 상태로 API 테스트를 수행 가능

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #4
