### PR TITLE
feat: 토큰 검증 기능과 reissue 로직 추가 및 개선

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -17,8 +17,6 @@ import authConfig from './config/modules/auth.config';
 import swaggerConfig from './config/modules/swagger.config';
 
 const logger = new Logger('DatabaseConnection');
-logger.log(`NODE_ENV: ${process.env.NODE_ENV}`);
-logger.log(`PORT: ${process.env.PORT}`);
 
 const PostgresModule = TypeOrmModule.forRootAsync({
   useClass: TypeOrmConfigService,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import postgresConfig from './database/config/postgres.config';
 import { PointHistoryModule } from './modules/point-history/point-history.module';
 import { RankingModule } from './modules/ranking/ranking.module';
 import authConfig from './config/modules/auth.config';
+import swaggerConfig from './config/modules/swagger.config';
 
 const logger = new Logger('DatabaseConnection');
 logger.log(`NODE_ENV: ${process.env.NODE_ENV}`);
@@ -33,7 +34,7 @@ const PostgresModule = TypeOrmModule.forRootAsync({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      load: [appConfig, postgresConfig, authConfig],
+      load: [appConfig, postgresConfig, authConfig, swaggerConfig],
       envFilePath: `.env.${process.env.NODE_ENV}`,
     }),
     PostgresModule,

--- a/src/common/constants/error-messages.ts
+++ b/src/common/constants/error-messages.ts
@@ -1,0 +1,12 @@
+export const AUTH_ERROR_MESSAGES = {
+  TOKEN_REQUIRED: '토큰이 필요합니다.',
+  INVALID_TOKEN: '유효하지 않은 토큰입니다.',
+  TOKEN_EXPIRED: '만료된 토큰입니다.',
+  UNAUTHORIZED: '인증되지 않은 사용자입니다.',
+  FORBIDDEN: '접근 권한이 없습니다.',
+} as const;
+
+export const USER_ERROR_MESSAGES = {
+  USER_NOT_FOUND: '사용자를 찾을 수 없습니다.',
+  USER_CREATE_FAILED: '유저 생성에 실패했습니다.',
+} as const;

--- a/src/common/decorator/public.decorator.ts
+++ b/src/common/decorator/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/common/decorator/role.decorator.ts
+++ b/src/common/decorator/role.decorator.ts
@@ -1,0 +1,5 @@
+import { SetMetadata } from '@nestjs/common';
+import { Role } from 'src/modules/user/domain/role.enum';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: Role[]) => SetMetadata(ROLES_KEY, roles);

--- a/src/common/decorator/user.decorator.ts
+++ b/src/common/decorator/user.decorator.ts
@@ -1,0 +1,14 @@
+import { ExecutionContext } from '@nestjs/common';
+
+import { createParamDecorator } from '@nestjs/common';
+
+export const User = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);
+
+export interface UserAfterAuth {
+  id: string;
+}

--- a/src/config/modules/app.config.ts
+++ b/src/config/modules/app.config.ts
@@ -1,6 +1,6 @@
 import { registerAs } from '@nestjs/config';
 import validateConfig from 'src/utils/validate-config';
-import { IsEnum, IsOptional } from 'class-validator';
+import { IsEnum, IsNumber, IsOptional, IsString } from 'class-validator';
 import { AppConfig } from '../types/app-config.type';
 
 enum Environment {
@@ -13,6 +13,12 @@ class EnvironmentVariablesValidator {
   @IsEnum(Environment)
   @IsOptional()
   NODE_ENV: Environment;
+
+  @IsNumber()
+  PORT: number;
+
+  @IsString()
+  CLIENT_URL: string;
 }
 
 export default registerAs<AppConfig>('app', () => {
@@ -20,7 +26,6 @@ export default registerAs<AppConfig>('app', () => {
   return {
     nodeEnv: process.env.NODE_ENV || 'development',
     port: parseInt(process.env.PORT) || 4000,
-    apiKey: process.env.KAKAO_API_KEY,
-    redirectUri: process.env.KAKAO_REDIRECT_URI,
+    clientUrl: process.env.CLIENT_URL,
   };
 });

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,15 +26,14 @@ async function bootstrap() {
       }),
     );
     const config = new DocumentBuilder()
-      .setTitle('NestJS project')
-      .setDescription('NestJS project API description')
+      .setTitle('CSHub API')
+      .setDescription('CSHub API description')
       .setVersion('1.0')
       .addBearerAuth()
       .build();
     const customOptions: SwaggerCustomOptions = {
       swaggerOptions: {
-        // TODO : 인증 구현 후 true로 변경
-        persistAuthorization: false,
+        persistAuthorization: true,
       },
     };
     const document = SwaggerModule.createDocument(app, config);

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { AuthController } from './presentation/auth.controller';
 import { AuthService } from './application/auth.service';
 import { HttpModule } from '@nestjs/axios';
@@ -7,6 +7,8 @@ import { JwtModule } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import { JwtStrategy } from './strategy/jwt.strategy';
 import { KakaoAuthClient } from './infrastructure/external/kakao/kakao-auth.client';
+import { APP_GUARD } from '@nestjs/core';
+import { JwtAuthGuard } from './jwt-auth.guard';
 
 @Module({
   imports: [
@@ -29,7 +31,16 @@ import { KakaoAuthClient } from './infrastructure/external/kakao/kakao-auth.clie
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, KakaoAuthClient],
+  providers: [
+    AuthService,
+    JwtStrategy,
+    KakaoAuthClient,
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard,
+    },
+    Logger,
+  ],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/src/modules/auth/domain/cookie.constant.ts
+++ b/src/modules/auth/domain/cookie.constant.ts
@@ -1,17 +1,13 @@
 export const ACCESS_TOKEN_COOKIE_CONFIG = {
   httpOnly: true,
-  // TODO : 배포 후 개발 환경에 따라 다르게 구성
-  secure: false,
+  secure: true,
   sameSite: 'lax',
   maxAge: 60 * 60 * 1000, // 1시간
-  signed: true,
 } as const;
 
 export const REFRESH_TOKEN_COOKIE_CONFIG = {
   httpOnly: true,
-  // TODO : 배포 후 개발 환경에 따라 다르게 구성
-  secure: false,
+  secure: true,
   sameSite: 'lax',
   maxAge: 7 * 24 * 60 * 60 * 1000, // 7일
-  signed: true,
 } as const;

--- a/src/modules/auth/jwt-auth.guard.ts
+++ b/src/modules/auth/jwt-auth.guard.ts
@@ -10,11 +10,13 @@ import { Reflector } from '@nestjs/core';
 import { JwtService } from '@nestjs/jwt';
 import { AuthGuard } from '@nestjs/passport';
 import { UserService } from '../user/application/user.service';
-import { Observable } from 'rxjs';
+import { Observable, firstValueFrom } from 'rxjs';
 import { Role } from '../user/domain/role.enum';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 import { IS_PUBLIC_KEY } from 'src/common/decorator/public.decorator';
 import { ROLES_KEY } from 'src/common/decorator/role.decorator';
+import { ACCESS_TOKEN_COOKIE_CONFIG } from './domain/cookie.constant';
+import { AUTH_ERROR_MESSAGES } from 'src/common/constants/error-messages';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
@@ -31,45 +33,132 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
   canActivate(
     context: ExecutionContext,
   ): boolean | Promise<boolean> | Observable<boolean> {
-    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+    if (this.isPublicRoute(context)) return true;
+
+    const { request, response } = this.getHttpContext(context);
+    const { accessToken, refreshToken } = this.extractTokens(
+      request.headers.cookie,
+    );
+
+    if (!accessToken && !refreshToken) {
+      this.throwUnauthorized(AUTH_ERROR_MESSAGES.TOKEN_REQUIRED);
+    }
+
+    return this.validateTokens(context, accessToken, refreshToken, response);
+  }
+
+  private isPublicRoute(context: ExecutionContext): boolean {
+    return this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
       context.getHandler(),
       context.getClass(),
     ]);
-    if (isPublic) return true;
+  }
 
+  private getHttpContext(context: ExecutionContext) {
     const http = context.switchToHttp();
-    const { url, headers } = http.getRequest<Request>();
-    const token = headers.authorization?.split(' ')[1];
+    return {
+      request: http.getRequest<Request>(),
+      response: http.getResponse<Response>(),
+    };
+  }
 
-    if (!token) {
-      const error = new UnauthorizedException('토큰이 없습니다');
-      this.logger.error(error.message, error.stack);
-      throw error;
+  private extractTokens(cookie: string) {
+    return {
+      accessToken: this.extractTokenFromCookie(cookie, 'access_token'),
+      refreshToken: this.extractTokenFromCookie(cookie, 'refresh_token'),
+    };
+  }
+
+  private async validateTokens(
+    context: ExecutionContext,
+    accessToken: string,
+    refreshToken: string,
+    response: Response,
+  ): Promise<boolean> {
+    let decodedToken = await this.verifyAccessToken(accessToken);
+
+    if (!decodedToken && refreshToken) {
+      decodedToken = await this.verifyRefreshTokenAndSignAccessToken(
+        refreshToken,
+        response,
+      );
     }
 
-    const decoded = this.jwtService.verify(token);
-    if (!decoded) {
-      const error = new UnauthorizedException('토큰이 유효하지 않습니다.');
-      this.logger.error(error.message, error.stack);
-      throw error;
+    if (!decodedToken) {
+      return firstValueFrom(super.canActivate(context) as Observable<boolean>);
     }
 
-    if (url !== '/auth/refresh' && decoded['tokenType'] === 'refresh') {
-      const error = new UnauthorizedException('access token이 필요합니다.');
-      this.logger.error(error.message, error.stack);
-      throw error;
-    }
+    return this.checkRolePermission(context, decodedToken.id);
+  }
 
+  private async verifyAccessToken(accessToken: string) {
+    if (!accessToken) return null;
+
+    try {
+      const decoded = this.jwtService.verify(accessToken);
+      if (decoded.tokenType === 'refresh') {
+        this.throwUnauthorized(AUTH_ERROR_MESSAGES.TOKEN_REQUIRED);
+      }
+      return decoded;
+    } catch (error) {
+      this.logger.error(AUTH_ERROR_MESSAGES.INVALID_TOKEN, error.message);
+      return null;
+    }
+  }
+
+  private async verifyRefreshTokenAndSignAccessToken(
+    refreshToken: string,
+    response: Response,
+  ) {
+    try {
+      const refreshDecoded = this.jwtService.verify(refreshToken);
+      if (refreshDecoded.tokenType !== 'refresh') {
+        this.throwUnauthorized(AUTH_ERROR_MESSAGES.INVALID_TOKEN);
+      }
+
+      const newAccessToken = this.jwtService.sign({
+        id: refreshDecoded.id,
+        tokenType: 'access',
+      });
+
+      response.cookie(
+        'access_token',
+        newAccessToken,
+        ACCESS_TOKEN_COOKIE_CONFIG,
+      );
+      return this.jwtService.verify(newAccessToken);
+    } catch (error) {
+      this.logger.error(AUTH_ERROR_MESSAGES.INVALID_TOKEN, error.message);
+      this.throwUnauthorized(AUTH_ERROR_MESSAGES.TOKEN_EXPIRED);
+    }
+  }
+
+  private async checkRolePermission(
+    context: ExecutionContext,
+    userId: string,
+  ): Promise<boolean> {
     const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
       context.getHandler(),
       context.getClass(),
     ]);
 
     if (requiredRoles) {
-      const userId = decoded['sub'];
       return this.userService.checkUserIsAdmin(userId);
     }
 
-    return super.canActivate(context);
+    return true;
+  }
+
+  private throwUnauthorized(message: string): never {
+    const error = new UnauthorizedException(message);
+    this.logger.error(error.message, error.stack);
+    throw error;
+  }
+
+  private extractTokenFromCookie(cookie: string, tokenName: string): string {
+    return cookie
+      ?.split(';')
+      .find((c) => c.trim().startsWith(`${tokenName}=`))
+      ?.split('=')[1];
   }
 }

--- a/src/modules/auth/jwt-auth.guard.ts
+++ b/src/modules/auth/jwt-auth.guard.ts
@@ -1,0 +1,75 @@
+import {
+  ExecutionContext,
+  Inject,
+  Injectable,
+  Logger,
+  LoggerService,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { JwtService } from '@nestjs/jwt';
+import { AuthGuard } from '@nestjs/passport';
+import { UserService } from '../user/application/user.service';
+import { Observable } from 'rxjs';
+import { Role } from '../user/domain/role.enum';
+import { Request } from 'express';
+import { IS_PUBLIC_KEY } from 'src/common/decorator/public.decorator';
+import { ROLES_KEY } from 'src/common/decorator/role.decorator';
+
+@Injectable()
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(
+    private reflector: Reflector,
+    private jwtService: JwtService,
+    private userService: UserService,
+    @Inject(Logger)
+    private logger: LoggerService,
+  ) {
+    super();
+  }
+
+  canActivate(
+    context: ExecutionContext,
+  ): boolean | Promise<boolean> | Observable<boolean> {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) return true;
+
+    const http = context.switchToHttp();
+    const { url, headers } = http.getRequest<Request>();
+    const token = headers.authorization?.split(' ')[1];
+
+    if (!token) {
+      const error = new UnauthorizedException('토큰이 없습니다');
+      this.logger.error(error.message, error.stack);
+      throw error;
+    }
+
+    const decoded = this.jwtService.verify(token);
+    if (!decoded) {
+      const error = new UnauthorizedException('토큰이 유효하지 않습니다.');
+      this.logger.error(error.message, error.stack);
+      throw error;
+    }
+
+    if (url !== '/auth/refresh' && decoded['tokenType'] === 'refresh') {
+      const error = new UnauthorizedException('access token이 필요합니다.');
+      this.logger.error(error.message, error.stack);
+      throw error;
+    }
+
+    const requiredRoles = this.reflector.getAllAndOverride<Role[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (requiredRoles) {
+      const userId = decoded['sub'];
+      return this.userService.checkUserIsAdmin(userId);
+    }
+
+    return super.canActivate(context);
+  }
+}

--- a/src/modules/auth/presentation/auth.controller.ts
+++ b/src/modules/auth/presentation/auth.controller.ts
@@ -10,6 +10,7 @@ import { Response } from 'express';
 import { AuthService } from '../application/auth.service';
 import { ConfigService } from '@nestjs/config';
 import { KakaoUser } from '../domain/kakao-user.type';
+import { Public } from 'src/common/decorator/public.decorator';
 
 @Controller('auth')
 export class AuthController {
@@ -25,6 +26,7 @@ export class AuthController {
   }
 
   @Get('kakao/login')
+  @Public()
   @Header('Content-Type', 'text/html')
   async kakaoRedirect(@Res() res: Response): Promise<void> {
     const kakaoAuthorizationUrl = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${this.apiKey}&redirect_uri=${this.redirectUri}`;
@@ -32,6 +34,7 @@ export class AuthController {
   }
 
   @Get('kakao/callback')
+  @Public()
   async getKakaoInfo(@Query('code') code: string, @Res() res: Response) {
     const kakaoUser: KakaoUser = await this.authService.kakaoLogin(
       this.apiKey,

--- a/src/modules/auth/strategy/jwt.strategy.ts
+++ b/src/modules/auth/strategy/jwt.strategy.ts
@@ -8,7 +8,11 @@ import { JwtPayload } from './type/jwt-payload.type';
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(private readonly configService: ConfigService) {
     super({
-      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      jwtFromRequest: ExtractJwt.fromExtractors([
+        (request) => {
+          return request?.cookies?.access_token;
+        },
+      ]),
       ignoreExpiration: false,
       secretOrKey: configService.get<string>('auth.jwt.secret'),
     });

--- a/src/modules/user/application/user.service.ts
+++ b/src/modules/user/application/user.service.ts
@@ -4,6 +4,7 @@ import { User } from '../infrastructure/db/entity/user.entity';
 import { Repository } from 'typeorm';
 import { Provider } from '../domain/provider.enum';
 import { KakaoUser } from '../../auth/domain/kakao-user.type';
+import { Role } from '../domain/role.enum';
 @Injectable()
 export class UserService {
   constructor(
@@ -11,7 +12,7 @@ export class UserService {
   ) {}
 
   async findAll() {
-    return 'findAll';
+    return await this.userRepository.find();
   }
 
   async findOne(id: string) {
@@ -34,5 +35,10 @@ export class UserService {
     user.platformId = kakaoUser.kakaoId;
     user.provider = Provider.KAKAO;
     return await this.userRepository.save(user);
+  }
+
+  async checkUserIsAdmin(id: string) {
+    const user = await this.userRepository.findOneBy({ id });
+    return user.role === Role.ADMIN;
   }
 }

--- a/src/modules/user/presentation/user.controller.ts
+++ b/src/modules/user/presentation/user.controller.ts
@@ -4,6 +4,8 @@ import { UserService } from '../application/user.service';
 import { FindUserReqDto } from '../dto/req.dto';
 import { ApiGetResponse } from 'src/common/decorator/swagger.decorator';
 import { FindUserResDto } from '../dto/res.dto';
+import { UserAfterAuth } from 'src/common/decorator/user.decorator';
+import { User } from 'src/common/decorator/user.decorator';
 
 @ApiTags('User')
 @ApiExtraModels(FindUserReqDto, FindUserResDto)
@@ -12,8 +14,10 @@ export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Get()
-  async getUsers() {
-    return await this.userService.findAll();
+  async getUsers(@User() user: UserAfterAuth) {
+    console.log(user);
+    const users = await this.userService.findAll();
+    return users;
   }
 
   @ApiGetResponse(FindUserResDto)


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
기존 authorization 헤더를 기반으로 구현한 토큰 검증 로직을 쿠키 기반으로 변경했습니다.

AT가 없어도 RT가 있는경우 AT 쿠키를 재발급하고 클라이언트의 요청에 대해 정상적인 응답을 수행합니다.

적적하지 않던 쿠키 옵션을 개선했습니다.

인증과 관련된 3개의 데코레이터를 추가했습니다.
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ authorization 헤더 기반 토큰 검증에서 쿠키 기반 검증 방식으로 변경
- ✨ non-signed secure쿠키로 변경
- ✨ 인증 요구 라우터 구분, 역할 기반 접근 제어, 인증된 user객체 접근을 위한 데코레이터를 각각 구현
- ✨ AT와 RT의 payload 변경
- ✨  에러메세지 상수화

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #15 
- resolved

