### PR TITLE
feat: 카테고리 초기 데이터 생성 파일 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
+    "seed:run": "cross-env NODE_ENV=local ts-node -r tsconfig-paths/register ./src/database/seed/run-seed.ts",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -1,0 +1,39 @@
+import 'reflect-metadata';
+import { DataSource, DataSourceOptions } from 'typeorm';
+
+export const AppDataSource = new DataSource({
+  type: process.env.DATABASE_TYPE,
+  url: process.env.DATABASE_URL,
+  //   host: process.env.DATABASE_HOST,
+  port: process.env.DATABASE_PORT
+    ? parseInt(process.env.DATABASE_PORT, 10)
+    : 5432,
+  username: process.env.DATABASE_USERNAME,
+  password: process.env.DATABASE_PASSWORD,
+  database: process.env.DATABASE_NAME,
+  synchronize: process.env.DATABASE_SYNCHRONIZE === 'true',
+  dropSchema: false,
+  keepConnectionAlive: true,
+  logging: process.env.NODE_ENV !== 'production',
+  entities: [__dirname + '/../**/*.entity{.ts,.js}'],
+  migrations: [__dirname + '/migrations/**/*{.ts,.js}'],
+  cli: {
+    entitiesDir: 'src',
+    subscribersDir: 'subscriber',
+  },
+  extra: {
+    max: process.env.DATABASE_MAX_CONNECTIONS
+      ? parseInt(process.env.DATABASE_MAX_CONNECTIONS, 10)
+      : 100,
+    ssl:
+      process.env.DATABASE_SSL_ENABLED === 'true'
+        ? {
+            rejectUnauthorized:
+              process.env.DATABASE_REJECT_UNAUTHORIZED === 'true',
+            ca: process.env.DATABASE_CA ?? undefined,
+            key: process.env.DATABASE_KEY ?? undefined,
+            cert: process.env.DATABASE_CERT ?? undefined,
+          }
+        : undefined,
+  },
+} as DataSourceOptions);

--- a/src/database/seed/category/category-seed.module.ts
+++ b/src/database/seed/category/category-seed.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SubCategory } from 'src/modules/quiz/infrastructure/db/entity/sub-category.entity';
+import { CategorySeedService } from './category-seed.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SubCategory])],
+  providers: [CategorySeedService],
+  exports: [CategorySeedService],
+})
+export class CategorySeedModule {}

--- a/src/database/seed/category/category-seed.service.ts
+++ b/src/database/seed/category/category-seed.service.ts
@@ -1,0 +1,77 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MainCategoryEnum } from 'src/modules/quiz/domain/main-category.enum';
+import { SubCategoryEnum } from 'src/modules/quiz/domain/sub-category.enum';
+import { SubCategory } from 'src/modules/quiz/infrastructure/db/entity/sub-category.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class CategorySeedService {
+  constructor(
+    @InjectRepository(SubCategory)
+    private subCategoryRepository: Repository<SubCategory>,
+  ) {}
+  async run() {
+    const countSubCategory = await this.subCategoryRepository.count({});
+    if (!countSubCategory) {
+      await this.subCategoryRepository.manager.transaction(async (manager) => {
+        // FE
+        await manager.save(SubCategory, [
+          { name: SubCategoryEnum.BROWSER, main_category: MainCategoryEnum.FE },
+          { name: SubCategoryEnum.REACT, main_category: MainCategoryEnum.FE },
+          { name: SubCategoryEnum.NEXT, main_category: MainCategoryEnum.FE },
+          { name: SubCategoryEnum.HTML, main_category: MainCategoryEnum.FE },
+          { name: SubCategoryEnum.CSS, main_category: MainCategoryEnum.FE },
+          { name: SubCategoryEnum.FE_ETC, main_category: MainCategoryEnum.FE },
+        ]);
+
+        // BE
+        await manager.save(SubCategory, [
+          { name: SubCategoryEnum.OS, main_category: MainCategoryEnum.BE },
+          { name: SubCategoryEnum.DB, main_category: MainCategoryEnum.BE },
+          { name: SubCategoryEnum.NODE, main_category: MainCategoryEnum.BE },
+          { name: SubCategoryEnum.SPRING, main_category: MainCategoryEnum.BE },
+          { name: SubCategoryEnum.BE_ETC, main_category: MainCategoryEnum.BE },
+        ]);
+
+        // COMMON
+        await manager.save(SubCategory, [
+          {
+            name: SubCategoryEnum.NETWORK,
+            main_category: MainCategoryEnum.COMMON,
+          },
+          {
+            name: SubCategoryEnum.DATA_STRUCTURE,
+            main_category: MainCategoryEnum.COMMON,
+          },
+          {
+            name: SubCategoryEnum.ALGORITHM,
+            main_category: MainCategoryEnum.COMMON,
+          },
+          { name: SubCategoryEnum.WEB, main_category: MainCategoryEnum.COMMON },
+          { name: SubCategoryEnum.FIT, main_category: MainCategoryEnum.COMMON },
+          {
+            name: SubCategoryEnum.COMMON_ETC,
+            main_category: MainCategoryEnum.COMMON,
+          },
+        ]);
+
+        // LANGUAGE
+        await manager.save(SubCategory, [
+          {
+            name: SubCategoryEnum.JAVASCRIPT,
+            main_category: MainCategoryEnum.LANGUAGE,
+          },
+          {
+            name: SubCategoryEnum.TYPESCRIPT,
+            main_category: MainCategoryEnum.LANGUAGE,
+          },
+          {
+            name: SubCategoryEnum.JAVA,
+            main_category: MainCategoryEnum.LANGUAGE,
+          },
+        ]);
+      });
+    }
+  }
+}

--- a/src/database/seed/run-seed.ts
+++ b/src/database/seed/run-seed.ts
@@ -1,0 +1,13 @@
+import { NestFactory } from '@nestjs/core';
+import { CategorySeedService } from './category/category-seed.service';
+import { SeedModule } from './seed.module';
+
+const runSeed = async () => {
+  const app = await NestFactory.create(SeedModule);
+
+  await app.get(CategorySeedService).run();
+
+  await app.close();
+};
+
+void runSeed();

--- a/src/database/seed/seed.module.ts
+++ b/src/database/seed/seed.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+import { CategorySeedModule } from './category/category-seed.module';
+import { ConfigModule } from '@nestjs/config';
+import postgresConfig from '../config/postgres.config';
+import appConfig from 'src/config/modules/app.config';
+import { DataSourceOptions } from 'typeorm';
+import { TypeOrmConfigService } from '../typeorm-config.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+
+@Module({
+  imports: [
+    CategorySeedModule,
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [postgresConfig, appConfig],
+      envFilePath: [`.env.${process.env.NODE_ENV}`],
+    }),
+    TypeOrmModule.forRootAsync({
+      useClass: TypeOrmConfigService,
+      dataSourceFactory: async (options: DataSourceOptions) => {
+        return new DataSource(options).initialize();
+      },
+    }),
+  ],
+})
+export class SeedModule {}


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
데이터 베이스와 직접 연결을 위해 data source를 추가했습니다.
초기 카테고리를 생성을 위한 category seed 파일을 추가했습니다.

추후 추가되는 seed 파일들은 `pnpm seed:run` 명령어를 통해 같이 실행됩니다.
```
`pnpm seed:run` 명령어로 초기 카테고리 데이터를 생성 가능합니다.
초기 카테고리 데이터가 없는 경우에만 데이터가 생성됩니다.

![image](https://github.com/user-attachments/assets/3f5ffe82-1f03-47dc-aa0d-65d425648672)

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 데이터 소스 파일 추가
- ✨ 초기 카테고리 데이터를 생성하는 카테고리 시드 서비스 구현
- ✨ 시드 실행 스크립트 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #21 
