### PR TITLE
feat: 쿠키 옵션 변경 및 API 프리픽스 추가

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { TransformInterceptor } from './common/interceptor/transform.interceptor
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.setGlobalPrefix('api/v1');
 
   const configService = app.get(ConfigService);
 

--- a/src/modules/auth/domain/cookie.constant.ts
+++ b/src/modules/auth/domain/cookie.constant.ts
@@ -3,6 +3,7 @@ export const ACCESS_TOKEN_COOKIE_CONFIG = {
   secure: true,
   sameSite: 'lax',
   maxAge: 60 * 60 * 1000, // 1시간
+  domain: '.cshub.kr',
 } as const;
 
 export const REFRESH_TOKEN_COOKIE_CONFIG = {
@@ -10,4 +11,5 @@ export const REFRESH_TOKEN_COOKIE_CONFIG = {
   secure: true,
   sameSite: 'lax',
   maxAge: 7 * 24 * 60 * 60 * 1000, // 7일
+  domain: '.cshub.kr',
 } as const;


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
JWT를 담은 쿠키에 domain 옵션을 추가합니다.
`domain : .cshub.kr` 을 설정함으로써 모든 서브도메인에서 쿠키를 사용할 수 있도록 합니다.

API 엔드포인트에 프리픽스 `/api/v1`을 추가합니다.
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 쿠키 도메인 옵션 변경
- ✨ API 프리픽스 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed
- resolved

## ℹ️ 참고 사항

