### PR TITLE
feat: 인터뷰 전체 조회 기능 추가

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,7 @@ import { SwaggerCustomOptions } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import * as expressBasicAuth from 'express-basic-auth';
 import { ValidationPipe } from '@nestjs/common';
-import { TransformInterceptor } from './common/interceptor/transform.interceptor';
+// import { TransformInterceptor } from './common/interceptor/transform.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -54,7 +54,9 @@ async function bootstrap() {
       transform: true,
     }),
   );
-  app.useGlobalInterceptors(new TransformInterceptor());
+
+  // TODO: 추후 페이징 처리 시점에 활성화
+  // app.useGlobalInterceptors(new TransformInterceptor());
 
   await app.listen(configService.get('app.port'));
   console.log(`STAGE: ${configService.get('app.nodeEnv')}`);

--- a/src/modules/auth/domain/cookie.constant.ts
+++ b/src/modules/auth/domain/cookie.constant.ts
@@ -1,9 +1,18 @@
+import { ConfigService } from '@nestjs/config';
+
+const configService = new ConfigService();
+const isDevelopment = configService.get('NODE_ENV') === 'development';
+const isProduction = configService.get('NODE_ENV') === 'production';
+
+const domainConfig =
+  isDevelopment || isProduction ? { domain: '.cshub.kr' } : {};
+
 export const ACCESS_TOKEN_COOKIE_CONFIG = {
   httpOnly: true,
   secure: true,
   sameSite: 'lax',
   maxAge: 60 * 60 * 1000, // 1시간
-  domain: '.cshub.kr',
+  ...domainConfig,
 } as const;
 
 export const REFRESH_TOKEN_COOKIE_CONFIG = {
@@ -11,5 +20,5 @@ export const REFRESH_TOKEN_COOKIE_CONFIG = {
   secure: true,
   sameSite: 'lax',
   maxAge: 7 * 24 * 60 * 60 * 1000, // 7일
-  domain: '.cshub.kr',
+  ...domainConfig,
 } as const;

--- a/src/modules/quiz/application/interview.service.ts
+++ b/src/modules/quiz/application/interview.service.ts
@@ -1,36 +1,23 @@
-import { Injectable } from '@nestjs/common';
-import { Repository } from 'typeorm';
-import { Interview } from '../infrastructure/db/entity/interview.entity';
-import { InjectRepository } from '@nestjs/typeorm';
+import { Inject, Injectable } from '@nestjs/common';
 import { CreateInterviewReqDto } from '../dto/interview.req.dto';
-import { CategoryService } from './catgegory.service';
+import { IInterviewRepository } from '../domain/repository/iinterview.repository';
+import { InterviewGroupMapper } from '../domain/mapper/interview-group.mapper';
+import { GetAllInterviewResDto } from '../dto/interview.res.dto';
 
 @Injectable()
 export class InterviewService {
   constructor(
-    @InjectRepository(Interview)
-    private readonly interviewRepository: Repository<Interview>,
-    private readonly categoryService: CategoryService,
+    @Inject('IInterviewRepository')
+    private readonly interviewRepository: IInterviewRepository,
   ) {}
 
-  async createInterview({
-    question,
-    answer,
-    keywords,
-    subCategory,
-  }: CreateInterviewReqDto) {
-    const subCategoryEntity =
-      await this.categoryService.findSubCategory(subCategory);
-    const interview = this.interviewRepository.create({
-      question,
-      answer,
-      keywords,
-      subCategory: subCategoryEntity,
-    });
-    return await this.interviewRepository.save(interview);
+  async createInterview(createInterviewReqDto: CreateInterviewReqDto) {
+    return await this.interviewRepository.create(createInterviewReqDto);
   }
 
-  async getAllInterview() {
-    return this.interviewRepository.find();
+  async getAllInterview(): Promise<GetAllInterviewResDto> {
+    const interviews = await this.interviewRepository.findAll();
+    const interviewGroups = InterviewGroupMapper.toGroups(interviews);
+    return { items: interviewGroups };
   }
 }

--- a/src/modules/quiz/domain/interview-group.type.ts
+++ b/src/modules/quiz/domain/interview-group.type.ts
@@ -1,0 +1,9 @@
+import { Interview } from './interview';
+
+export type InterviewGroup = {
+  mainCategoryName: string;
+  subCategoryName: string;
+  interviews: Interview[];
+};
+
+export type InterviewGroups = Record<string, InterviewGroup>;

--- a/src/modules/quiz/domain/interview-group.type.ts
+++ b/src/modules/quiz/domain/interview-group.type.ts
@@ -1,9 +1,9 @@
-import { Interview } from './interview';
+import { InterviewResDto } from '../dto/interview.res.dto';
 
 export type InterviewGroup = {
   mainCategoryName: string;
   subCategoryName: string;
-  interviews: Interview[];
+  interviews: InterviewResDto[];
 };
 
 export type InterviewGroups = Record<string, InterviewGroup>;

--- a/src/modules/quiz/domain/interview.ts
+++ b/src/modules/quiz/domain/interview.ts
@@ -1,1 +1,47 @@
-export class Interview {}
+import { ApiProperty } from '@nestjs/swagger';
+
+export class Interview {
+  @ApiProperty({
+    description: '인터뷰 ID',
+    example: 1,
+  })
+  id: number;
+
+  @ApiProperty({
+    description: '서브 카테고리 정보',
+    example: {
+      id: 1,
+      name: 'NETWORK',
+      main_category: 'COMMON',
+    },
+  })
+  subCategory: {
+    id: number;
+    name: string;
+    main_category: string;
+  };
+
+  @ApiProperty({
+    description: '질문',
+    example: 'HTTP와 HTTPS의 차이점은 무엇인가요?',
+  })
+  question: string;
+
+  @ApiProperty({
+    description: '답변',
+    example:
+      'HTTP는 암호화되지 않은 평문 통신이며, HTTPS는 SSL/TLS를 통해 암호화된 통신을 합니다.',
+  })
+  answer: string;
+
+  @ApiProperty({
+    description: '키워드 목록',
+    example: ['HTTP', 'HTTPS', 'SSL', 'TLS', '보안'],
+  })
+  keywords: string[];
+
+  @ApiProperty({
+    description: '생성일시',
+  })
+  createdAt: Date;
+}

--- a/src/modules/quiz/domain/mapper/interview-group.mapper.ts
+++ b/src/modules/quiz/domain/mapper/interview-group.mapper.ts
@@ -1,0 +1,44 @@
+import { Interview } from '../interview';
+import { InterviewGroup, InterviewGroups } from '../interview-group.type';
+
+export class InterviewGroupMapper {
+  static toGroups(interviews: Interview[]): InterviewGroup[] {
+    const groupedInterviews = this.groupInterviewsByCategory(interviews);
+    return Object.values(groupedInterviews);
+  }
+
+  private static groupInterviewsByCategory(
+    interviews: Interview[],
+  ): InterviewGroups {
+    return interviews.reduce((acc, interview) => {
+      const { name: categoryName, main_category: mainCategoryName } =
+        interview.subCategory;
+      const key = this.generateGroupKey(mainCategoryName, categoryName);
+
+      if (!acc[key]) {
+        acc[key] = this.createNewGroup(mainCategoryName, categoryName);
+      }
+
+      acc[key].interviews.push(interview);
+      return acc;
+    }, {} as InterviewGroups);
+  }
+
+  private static generateGroupKey(
+    mainCategory: string,
+    subCategory: string,
+  ): string {
+    return `${mainCategory}-${subCategory}`;
+  }
+
+  private static createNewGroup(
+    mainCategoryName: string,
+    subCategoryName: string,
+  ): InterviewGroup {
+    return {
+      mainCategoryName,
+      subCategoryName,
+      interviews: [],
+    };
+  }
+}

--- a/src/modules/quiz/domain/mapper/interview-group.mapper.ts
+++ b/src/modules/quiz/domain/mapper/interview-group.mapper.ts
@@ -1,10 +1,21 @@
 import { Interview } from '../interview';
 import { InterviewGroup, InterviewGroups } from '../interview-group.type';
+import { InterviewResDto } from '../../dto/interview.res.dto';
 
 export class InterviewGroupMapper {
   static toGroups(interviews: Interview[]): InterviewGroup[] {
     const groupedInterviews = this.groupInterviewsByCategory(interviews);
     return Object.values(groupedInterviews);
+  }
+
+  private static toResponseDto(interview: Interview): InterviewResDto {
+    return {
+      id: interview.id,
+      question: interview.question,
+      answer: interview.answer,
+      keywords: interview.keywords,
+      createdAt: interview.createdAt,
+    };
   }
 
   private static groupInterviewsByCategory(
@@ -19,7 +30,7 @@ export class InterviewGroupMapper {
         acc[key] = this.createNewGroup(mainCategoryName, categoryName);
       }
 
-      acc[key].interviews.push(interview);
+      acc[key].interviews.push(this.toResponseDto(interview));
       return acc;
     }, {} as InterviewGroups);
   }

--- a/src/modules/quiz/domain/mapper/interview.mapper.ts
+++ b/src/modules/quiz/domain/mapper/interview.mapper.ts
@@ -1,0 +1,25 @@
+import { Interview as InterviewEntity } from '../../infrastructure/db/entity/interview.entity';
+import { Interview as InterviewDomain } from '../interview';
+
+export class InterviewMapper {
+  static toDomain(entity: InterviewEntity): InterviewDomain {
+    const domain = new InterviewDomain();
+
+    domain.id = entity.id;
+    domain.question = entity.question;
+    domain.answer = entity.answer;
+    domain.keywords = entity.keywords;
+    domain.subCategory = {
+      id: entity.subCategory.id,
+      name: entity.subCategory.name,
+      main_category: entity.subCategory.main_category,
+    };
+    domain.createdAt = entity.created_at;
+
+    return domain;
+  }
+
+  static toDomainList(entities: InterviewEntity[]): InterviewDomain[] {
+    return entities.map((entity) => this.toDomain(entity));
+  }
+}

--- a/src/modules/quiz/domain/repository/iinterview.repository.ts
+++ b/src/modules/quiz/domain/repository/iinterview.repository.ts
@@ -1,0 +1,9 @@
+import { CreateInterviewReqDto } from '../../dto/interview.req.dto';
+import { Interview } from '../interview';
+
+export interface IInterviewRepository {
+  create(data: CreateInterviewReqDto): Promise<Interview>;
+  findAll(): Promise<Interview[]>;
+  findOne(id: number): Promise<Interview>;
+  findBySubCategory(subCategoryId: number): Promise<Interview[]>;
+}

--- a/src/modules/quiz/dto/interview.res.dto.ts
+++ b/src/modules/quiz/dto/interview.res.dto.ts
@@ -1,9 +1,37 @@
 import { ApiProperty } from '@nestjs/swagger';
-
+import { Interview } from '../domain/interview';
 export class CreateInterviewResDto {
   @ApiProperty({
     description: '인터뷰 ID',
     example: 1,
   })
   id: number;
+}
+
+export class GetInterviewByCategoryResDto {
+  @ApiProperty({
+    description: '메인 카테고리명',
+    example: 'COMMON',
+  })
+  mainCategoryName: string;
+
+  @ApiProperty({
+    description: '서브 카테고리명',
+    example: 'NETWORK',
+  })
+  subCategoryName: string;
+
+  @ApiProperty({
+    description: '인터뷰 목록',
+    type: [Interview],
+  })
+  interviews: Interview[];
+}
+
+export class GetAllInterviewResDto {
+  @ApiProperty({
+    description: '카테고리별 인터뷰 목록',
+    type: [GetInterviewByCategoryResDto],
+  })
+  items: GetInterviewByCategoryResDto[];
 }

--- a/src/modules/quiz/dto/interview.res.dto.ts
+++ b/src/modules/quiz/dto/interview.res.dto.ts
@@ -1,5 +1,4 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Interview } from '../domain/interview';
 export class CreateInterviewResDto {
   @ApiProperty({
     description: '인터뷰 ID',
@@ -8,6 +7,37 @@ export class CreateInterviewResDto {
   id: number;
 }
 
+export class InterviewResDto {
+  @ApiProperty({
+    description: '인터뷰 ID',
+    example: 1,
+  })
+  id: number;
+
+  @ApiProperty({
+    description: '질문',
+    example: 'HTTP와 HTTPS의 차이점은 무엇인가요?',
+  })
+  question: string;
+
+  @ApiProperty({
+    description: '답변',
+    example:
+      'HTTP는 암호화되지 않은 평문 통신이며, HTTPS는 SSL/TLS를 통해 암호화된 통신을 합니다.',
+  })
+  answer: string;
+
+  @ApiProperty({
+    description: '키워드 목록',
+    example: ['HTTP', 'HTTPS', 'SSL', 'TLS', '보안'],
+  })
+  keywords: string[];
+
+  @ApiProperty({
+    description: '생성일시',
+  })
+  createdAt: Date;
+}
 export class GetInterviewByCategoryResDto {
   @ApiProperty({
     description: '메인 카테고리명',
@@ -23,9 +53,9 @@ export class GetInterviewByCategoryResDto {
 
   @ApiProperty({
     description: '인터뷰 목록',
-    type: [Interview],
+    type: [InterviewResDto],
   })
-  interviews: Interview[];
+  interviews: InterviewResDto[];
 }
 
 export class GetAllInterviewResDto {

--- a/src/modules/quiz/infrastructure/db/repository/interview.repository.ts
+++ b/src/modules/quiz/infrastructure/db/repository/interview.repository.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Interview as InterviewEntity } from '../entity/interview.entity';
+import { Interview as InterviewDomain } from '../../../domain/interview';
+import { CreateInterviewReqDto } from '../../../dto/interview.req.dto';
+import { SubCategory } from '../entity/sub-category.entity';
+import { IInterviewRepository } from 'src/modules/quiz/domain/repository/iinterview.repository';
+import { InterviewMapper } from '../../../domain/mapper/interview.mapper';
+
+@Injectable()
+export class InterviewRepository implements IInterviewRepository {
+  constructor(
+    @InjectRepository(InterviewEntity)
+    private readonly repository: Repository<InterviewEntity>,
+    @InjectRepository(SubCategory)
+    private readonly subCategoryRepository: Repository<SubCategory>,
+  ) {}
+
+  async create(data: CreateInterviewReqDto): Promise<InterviewDomain> {
+    const subCategory = await this.subCategoryRepository.findOne({
+      where: { name: data.subCategory },
+    });
+
+    const interview = this.repository.create({
+      question: data.question,
+      answer: data.answer,
+      keywords: data.keywords,
+      subCategory,
+    });
+
+    const savedEntity = await this.repository.save(interview);
+    return InterviewMapper.toDomain(savedEntity);
+  }
+
+  async findAll(): Promise<InterviewDomain[]> {
+    const entities = await this.repository.find({
+      relations: {
+        subCategory: true,
+      },
+    });
+    return InterviewMapper.toDomainList(entities);
+  }
+
+  async findOne(id: number): Promise<InterviewDomain> {
+    const entity = await this.repository.findOne({
+      where: { id },
+      relations: {
+        subCategory: true,
+      },
+    });
+    return InterviewMapper.toDomain(entity);
+  }
+
+  async findBySubCategory(subCategoryId: number): Promise<InterviewDomain[]> {
+    const entities = await this.repository.find({
+      where: {
+        subCategory: { id: subCategoryId },
+      },
+      relations: {
+        subCategory: true,
+      },
+    });
+    return InterviewMapper.toDomainList(entities);
+  }
+}

--- a/src/modules/quiz/presentation/interview.controller.ts
+++ b/src/modules/quiz/presentation/interview.controller.ts
@@ -5,10 +5,20 @@ import { Roles } from 'src/common/decorator/role.decorator';
 import { Role } from 'src/modules/user/domain/role.enum';
 import { ApiBearerAuth, ApiExtraModels } from '@nestjs/swagger';
 import { ApiTags } from '@nestjs/swagger';
-import { CreateInterviewResDto } from '../dto/interview.res.dto';
+import {
+  CreateInterviewResDto,
+  GetAllInterviewResDto,
+  GetInterviewByCategoryResDto,
+} from '../dto/interview.res.dto';
+import { ApiGetResponse } from 'src/common/decorator/swagger.decorator';
 
 @ApiTags('Interview')
-@ApiExtraModels(CreateInterviewReqDto, CreateInterviewResDto)
+@ApiExtraModels(
+  CreateInterviewReqDto,
+  CreateInterviewResDto,
+  GetInterviewByCategoryResDto,
+  GetAllInterviewResDto,
+)
 @Controller('interviews')
 export class InterviewController {
   constructor(private readonly interviewService: InterviewService) {}
@@ -27,7 +37,8 @@ export class InterviewController {
   }
 
   @Get()
-  async getAllInterview() {
-    return this.interviewService.getAllInterview();
+  @ApiGetResponse(GetAllInterviewResDto)
+  async getAllInterview(): Promise<GetAllInterviewResDto> {
+    return await this.interviewService.getAllInterview();
   }
 }

--- a/src/modules/quiz/quiz.module.ts
+++ b/src/modules/quiz/quiz.module.ts
@@ -10,6 +10,7 @@ import { InterviewService } from './application/interview.service';
 import { Interview } from './infrastructure/db/entity/interview.entity';
 import { SubCategory } from './infrastructure/db/entity/sub-category.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { InterviewRepository } from './infrastructure/db/repository/interview.repository';
 
 @Module({
   imports: [TypeOrmModule.forFeature([Interview, SubCategory])],
@@ -19,7 +20,16 @@ import { TypeOrmModule } from '@nestjs/typeorm';
     CategoryController,
     InterviewController,
   ],
-  providers: [QuizService, LikeService, CategoryService, InterviewService],
+  providers: [
+    QuizService,
+    LikeService,
+    CategoryService,
+    InterviewService,
+    {
+      provide: 'IInterviewRepository',
+      useClass: InterviewRepository,
+    },
+  ],
   exports: [QuizService, LikeService, CategoryService, InterviewService],
 })
 export class QuizModule {}


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
인터뷰 전체 조회 기능을 추가했습니다.

인터뷰 모듈에 Repository 패턴을 적용하여 데이터 접근 로직과 비즈니스 로직의 책임을 분리하고, 코드 재사용성을 높였습니다. 

Data Mapper Pattern에 따라서 데이터베이스 엔티티와 애플리케이션의 도메인 객체를 분리하고, 엔티티 모델을 도메인 모델로 변환하는 mapper를 추가했습니다.

비즈니스 로직에서 처리하던 인터뷰 그룹화 변환 로직을 분리하기 위해  별도의 매퍼 클래스 InterviewGroupMapper를 구현했습니다.

이를 통해 비즈니스 로직과 데이터 변환 로직을 명확히 분리했습니다.

쿠키 도메인 옵션이 로컬 환경에서도 .cshub.kr로 지정되는 이슈가 있어서 STAGE에 따라 다르게 지정되게 변경했습니다.
```

응답 데이터 예시
```
{
  "items": [
    {
      "mainCategoryName": "COMMON",
      "subCategoryName": "NETWORK",
      "interviews": [
        {
          "id": 1,
          "question": "질문",
          "answer": "답변",
          "keywords": [
            "키워드1",
            "키워드2"
          ],
          "createdAt": "2024-11-26T19:56:14.016Z"
        },
        {
          "id": 2,
          "question": "질문",
          "answer": "답변",
          "keywords": [
            "키워드1",
            "키워드2"
          ],
          "createdAt": "2024-11-26T20:00:29.748Z"
        },
      ]
    }
  ]
}
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ 쿠키 도메인 옵션 환경에 따라 변경되게 처리
- ✨ 페이징 처리 인터셉터 임시 주석처리
- ✨ 엔티티 -> 도메인 매퍼 구현
- ✨ 인터뷰 리포지토리 패턴 적용
- ✨ 인터뷰 전체 조회 기능 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #25
- resolved

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

- Notion Docs에 `Repository 패턴과 Data Mapper 패턴 기반 비즈니스 로직 분리` 문서에 좀 더 자세히 적어두었습니다.
