### PR TITLE
feat: 좋아요 기능 추가

### DIFF
--- a/src/common/decorator/user.decorator.ts
+++ b/src/common/decorator/user.decorator.ts
@@ -1,6 +1,7 @@
 import { ExecutionContext } from '@nestjs/common';
 
 import { createParamDecorator } from '@nestjs/common';
+import { Role } from 'src/modules/user/domain/role.enum';
 
 export const User = createParamDecorator(
   (data: unknown, ctx: ExecutionContext) => {
@@ -10,5 +11,8 @@ export const User = createParamDecorator(
 );
 
 export interface UserAfterAuth {
-  id: string;
+  id: number;
+  role: Role;
+  profile_image: string;
+  nickname: string;
 }

--- a/src/database/seed/category/category-seed.service.ts
+++ b/src/database/seed/category/category-seed.service.ts
@@ -31,6 +31,7 @@ export class CategorySeedService {
           { name: SubCategoryEnum.DB, main_category: MainCategoryEnum.BE },
           { name: SubCategoryEnum.NODE, main_category: MainCategoryEnum.BE },
           { name: SubCategoryEnum.SPRING, main_category: MainCategoryEnum.BE },
+          { name: SubCategoryEnum.CLOUD, main_category: MainCategoryEnum.BE },
           { name: SubCategoryEnum.BE_ETC, main_category: MainCategoryEnum.BE },
         ]);
 
@@ -48,7 +49,6 @@ export class CategorySeedService {
             name: SubCategoryEnum.ALGORITHM,
             main_category: MainCategoryEnum.COMMON,
           },
-          { name: SubCategoryEnum.WEB, main_category: MainCategoryEnum.COMMON },
           { name: SubCategoryEnum.FIT, main_category: MainCategoryEnum.COMMON },
           {
             name: SubCategoryEnum.COMMON_ETC,

--- a/src/modules/auth/auth.module.ts
+++ b/src/modules/auth/auth.module.ts
@@ -16,18 +16,16 @@ import { JwtAuthGuard } from './jwt-auth.guard';
     UserModule,
     JwtModule.registerAsync({
       inject: [ConfigService],
-      useFactory: (configService: ConfigService) => {
-        return {
-          global: true,
-          secret: configService.get('auth.jwt.secret'),
-          signOptions: {
-            expiresIn: configService.get('auth.jwt.accessExpiresIn'),
-          },
-          refreshToken: {
-            expiresIn: configService.get('auth.jwt.refreshExpiresIn'),
-          },
-        };
-      },
+      useFactory: (configService: ConfigService) => ({
+        global: true,
+        secret: configService.get('auth.jwt.secret'),
+        signOptions: {
+          expiresIn: configService.get('auth.jwt.accessExpiresIn'),
+        },
+        refreshToken: {
+          expiresIn: configService.get('auth.jwt.refreshExpiresIn'),
+        },
+      }),
     }),
   ],
   controllers: [AuthController],
@@ -35,12 +33,13 @@ import { JwtAuthGuard } from './jwt-auth.guard';
     AuthService,
     JwtStrategy,
     KakaoAuthClient,
+    JwtAuthGuard,
     {
       provide: APP_GUARD,
       useClass: JwtAuthGuard,
     },
     Logger,
   ],
-  exports: [AuthService],
+  exports: [AuthService, JwtAuthGuard, JwtModule],
 })
 export class AuthModule {}

--- a/src/modules/auth/presentation/auth.controller.ts
+++ b/src/modules/auth/presentation/auth.controller.ts
@@ -55,7 +55,7 @@ export class AuthController {
       JwtPayload,
       'id' | 'role' | 'profile_image' | 'nickname'
     > = {
-      id: user.id,
+      id: user.id.toString(),
       role: user.role,
       profile_image: user.profile_image,
       nickname: user.nickname,

--- a/src/modules/auth/strategy/jwt.strategy.ts
+++ b/src/modules/auth/strategy/jwt.strategy.ts
@@ -22,6 +22,11 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     if (!payload.id) {
       throw new UnauthorizedException();
     }
-    return payload;
+    return {
+      id: parseInt(payload.id),
+      role: payload.role,
+      profile_image: payload.profile_image,
+      nickname: payload.nickname,
+    };
   }
 }

--- a/src/modules/quiz/application/interview.service.ts
+++ b/src/modules/quiz/application/interview.service.ts
@@ -6,13 +6,15 @@ import {
   CreateInterviewResDto,
   FindInterviewInfoResDto,
   FindAllInterviewResDto,
+  FindInterviewInfoWithLikeResDto,
 } from '../dto/interview.res.dto';
-
+import { LikeService } from './like.service';
 @Injectable()
 export class InterviewService {
   constructor(
     @Inject('IInterviewRepository')
     private readonly interviewRepository: IInterviewRepository,
+    private readonly likeService: LikeService,
   ) {}
 
   async create(
@@ -30,8 +32,21 @@ export class InterviewService {
     return { items: interviewGroups };
   }
 
-  async findOne(id: number): Promise<FindInterviewInfoResDto> {
+  async findOne(
+    id: number,
+    userId?: number,
+  ): Promise<FindInterviewInfoResDto | FindInterviewInfoWithLikeResDto> {
     const interview = await this.interviewRepository.findById(id);
-    return interview;
+
+    if (!userId) {
+      return interview;
+    }
+
+    const like = await this.likeService.findOne(id, userId);
+
+    return {
+      ...interview,
+      isLiked: !!like,
+    };
   }
 }

--- a/src/modules/quiz/application/like.service.ts
+++ b/src/modules/quiz/application/like.service.ts
@@ -1,4 +1,61 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Like } from '../infrastructure/db/entity/like.entity';
+import { LikeTargetType, ToggleLikeReqDto } from '../dto/like.req.dto';
 
 @Injectable()
-export class LikeService {}
+export class LikeService {
+  constructor(
+    @InjectRepository(Like)
+    private readonly likeRepository: Repository<Like>,
+  ) {}
+
+  async findOne(id: number, userId: number) {
+    return await this.likeRepository.findOne({
+      where: {
+        user: { id: userId },
+        interview: { id },
+      },
+    });
+  }
+
+  async toggleLike(
+    userId: number,
+    params: ToggleLikeReqDto,
+  ): Promise<{ isLiked: boolean }> {
+    return await this.likeRepository.manager.transaction(
+      async (transactionalEntityManager) => {
+        const { type, targetId } = params;
+        const isInterview = type === LikeTargetType.INTERVIEW;
+        const targetEntity = isInterview ? 'interview' : 'quiz';
+
+        const whereCondition = {
+          user: { id: userId },
+          [targetEntity]: { id: targetId },
+        };
+
+        const existingLike = await transactionalEntityManager
+          .getRepository(Like)
+          .createQueryBuilder('like')
+          .setLock('pessimistic_write')
+          .where(whereCondition)
+          .getOne();
+
+        if (existingLike) {
+          await transactionalEntityManager.remove(existingLike);
+          return { isLiked: false };
+        }
+
+        const newLike = transactionalEntityManager.create(Like, {
+          user: { id: userId },
+          [targetEntity]: { id: targetId },
+          [isInterview ? 'quiz' : 'interview']: null,
+        });
+
+        await transactionalEntityManager.save(newLike);
+        return { isLiked: true };
+      },
+    );
+  }
+}

--- a/src/modules/quiz/domain/like.ts
+++ b/src/modules/quiz/domain/like.ts
@@ -1,1 +1,7 @@
-export class Like {}
+export class Like {
+  id: number;
+  userId: number;
+  interviewId?: number;
+  quizId?: number;
+  createdAt: Date;
+}

--- a/src/modules/quiz/domain/sub-category.enum.ts
+++ b/src/modules/quiz/domain/sub-category.enum.ts
@@ -12,13 +12,13 @@ export enum SubCategoryEnum {
   DB = 'DB',
   NODE = 'NODE',
   SPRING = 'SPRING',
+  CLOUD = 'CLOUD',
   BE_ETC = 'BE_ETC',
 
   // COMMON
   NETWORK = 'NETWORK',
   DATA_STRUCTURE = 'DATA_STRUCTURE',
   ALGORITHM = 'ALGORITHM',
-  WEB = 'WEB',
   FIT = 'FIT',
   COMMON_ETC = 'COMMON_ETC',
 

--- a/src/modules/quiz/dto/interview.res.dto.ts
+++ b/src/modules/quiz/dto/interview.res.dto.ts
@@ -53,6 +53,14 @@ export class FindInterviewInfoResDto {
   createdAt: Date;
 }
 
+export class FindInterviewInfoWithLikeResDto extends FindInterviewInfoResDto {
+  @ApiProperty({
+    description: '좋아요 여부',
+    example: true,
+  })
+  isLiked: boolean;
+}
+
 export class FindInterviewResDto {
   @ApiProperty({
     description: '인터뷰 ID',

--- a/src/modules/quiz/dto/like.req.dto.ts
+++ b/src/modules/quiz/dto/like.req.dto.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsEnum, IsNumber } from 'class-validator';
+
+export enum LikeTargetType {
+  INTERVIEW = 'interview',
+  QUIZ = 'quiz',
+}
+
+export class ToggleLikeReqDto {
+  @ApiProperty({
+    description: '좋아요 대상 타입',
+    enum: LikeTargetType,
+    example: LikeTargetType.INTERVIEW,
+  })
+  @IsEnum(LikeTargetType)
+  type: LikeTargetType;
+
+  @ApiProperty({
+    description: '좋아요 대상 ID',
+    example: 1,
+  })
+  @IsNumber()
+  targetId: number;
+}

--- a/src/modules/quiz/dto/like.res.dto.ts
+++ b/src/modules/quiz/dto/like.res.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ToggleLikeResDto {
+  @ApiProperty({
+    description: '좋아요 상태',
+    example: true,
+    type: Boolean,
+  })
+  isLiked: boolean;
+}

--- a/src/modules/quiz/infrastructure/db/entity/interview.entity.ts
+++ b/src/modules/quiz/infrastructure/db/entity/interview.entity.ts
@@ -7,8 +7,10 @@ import {
   UpdateDateColumn,
   DeleteDateColumn,
   JoinColumn,
+  OneToMany,
 } from 'typeorm';
 import { SubCategory } from './sub-category.entity';
+import { Like } from './like.entity';
 
 @Entity()
 export class Interview {
@@ -36,4 +38,7 @@ export class Interview {
 
   @DeleteDateColumn()
   deleted_at: Date;
+
+  @OneToMany(() => Like, (like) => like.quiz)
+  likes: Like[];
 }

--- a/src/modules/quiz/infrastructure/db/entity/like.entity.ts
+++ b/src/modules/quiz/infrastructure/db/entity/like.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { User } from 'src/modules/user/infrastructure/db/entity/user.entity';
+import { Interview } from './interview.entity';
+import { ChoiceQuiz } from './choice-quiz.entity';
+
+@Entity()
+export class Like {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, { nullable: false })
+  @JoinColumn({ name: 'user_id' })
+  user: User;
+
+  @ManyToOne(() => Interview, { nullable: true })
+  @JoinColumn({ name: 'interview_id' })
+  interview: Interview;
+
+  @ManyToOne(() => ChoiceQuiz, { nullable: true })
+  @JoinColumn({ name: 'quiz_id' })
+  quiz: ChoiceQuiz;
+
+  @CreateDateColumn()
+  created_at: Date;
+}

--- a/src/modules/quiz/presentation/interview.controller.ts
+++ b/src/modules/quiz/presentation/interview.controller.ts
@@ -9,17 +9,19 @@ import {
   CreateInterviewResDto,
   FindInterviewInfoResDto,
   FindAllInterviewResDto,
-  FindInterviewByCategoryResDto,
+  FindInterviewInfoWithLikeResDto,
 } from '../dto/interview.res.dto';
 import { ApiGetResponse } from 'src/common/decorator/swagger.decorator';
+import { User, UserAfterAuth } from 'src/common/decorator/user.decorator';
+import { Public } from 'src/common/decorator/public.decorator';
 
 @ApiTags('Interview')
 @ApiExtraModels(
   CreateInterviewReqDto,
   CreateInterviewResDto,
-  FindInterviewByCategoryResDto,
   FindAllInterviewResDto,
   FindInterviewInfoResDto,
+  FindInterviewInfoWithLikeResDto,
 )
 @Controller('interviews')
 export class InterviewController {
@@ -34,15 +36,20 @@ export class InterviewController {
     return await this.interviewService.create(createInterviewReqDto);
   }
 
+  @Public()
   @Get()
   @ApiGetResponse(FindAllInterviewResDto)
   async findAll(): Promise<FindAllInterviewResDto> {
     return await this.interviewService.findAll();
   }
 
+  @Public()
   @Get(':id')
-  @ApiGetResponse(FindInterviewInfoResDto)
-  async findOne(@Param('id') id: number): Promise<FindInterviewInfoResDto> {
-    return await this.interviewService.findOne(id);
+  @ApiGetResponse(FindInterviewInfoWithLikeResDto)
+  async findOne(
+    @Param('id') id: number,
+    @User() user?: UserAfterAuth,
+  ): Promise<FindInterviewInfoResDto | FindInterviewInfoWithLikeResDto> {
+    return await this.interviewService.findOne(id, user?.id);
   }
 }

--- a/src/modules/quiz/presentation/like.controller.ts
+++ b/src/modules/quiz/presentation/like.controller.ts
@@ -1,4 +1,37 @@
-import { Controller } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Param,
+  UseGuards,
+  ParseIntPipe,
+} from '@nestjs/common';
+import { LikeService } from '../application/like.service';
+import { User, UserAfterAuth } from 'src/common/decorator/user.decorator';
+import { ApiTags, ApiBearerAuth, ApiExtraModels } from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/modules/auth/jwt-auth.guard';
+import { ApiPostResponse } from 'src/common/decorator/swagger.decorator';
+import { ToggleLikeResDto } from '../dto/like.res.dto';
+import { LikeTargetType, ToggleLikeReqDto } from '../dto/like.req.dto';
 
+@ApiTags('Like')
+@ApiExtraModels(ToggleLikeResDto, ToggleLikeReqDto)
 @Controller('likes')
-export class LikeController {}
+export class LikeController {
+  constructor(private readonly likeService: LikeService) {}
+
+  @Post(':type/:id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiPostResponse(ToggleLikeResDto)
+  async toggleLike(
+    @User() user: UserAfterAuth,
+    @Param('type') type: LikeTargetType,
+    @Param('id', ParseIntPipe) targetId: number,
+  ): Promise<ToggleLikeResDto> {
+    const params: ToggleLikeReqDto = {
+      type,
+      targetId,
+    };
+    return this.likeService.toggleLike(user.id, params);
+  }
+}

--- a/src/modules/quiz/presentation/like.controller.ts
+++ b/src/modules/quiz/presentation/like.controller.ts
@@ -4,12 +4,12 @@ import {
   Param,
   UseGuards,
   ParseIntPipe,
+  HttpCode,
 } from '@nestjs/common';
 import { LikeService } from '../application/like.service';
 import { User, UserAfterAuth } from 'src/common/decorator/user.decorator';
 import { ApiTags, ApiBearerAuth, ApiExtraModels } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/modules/auth/jwt-auth.guard';
-import { ApiPostResponse } from 'src/common/decorator/swagger.decorator';
 import { ToggleLikeResDto } from '../dto/like.res.dto';
 import { LikeTargetType, ToggleLikeReqDto } from '../dto/like.req.dto';
 
@@ -22,16 +22,16 @@ export class LikeController {
   @Post(':type/:id')
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
-  @ApiPostResponse(ToggleLikeResDto)
+  @HttpCode(200)
   async toggleLike(
     @User() user: UserAfterAuth,
     @Param('type') type: LikeTargetType,
     @Param('id', ParseIntPipe) targetId: number,
-  ): Promise<ToggleLikeResDto> {
+  ): Promise<void> {
     const params: ToggleLikeReqDto = {
       type,
       targetId,
     };
-    return this.likeService.toggleLike(user.id, params);
+    await this.likeService.toggleLike(user.id, params);
   }
 }

--- a/src/modules/quiz/quiz.module.ts
+++ b/src/modules/quiz/quiz.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { QuizController } from './presentation/quiz.controller';
 import { QuizService } from './application/quiz.service';
 import { LikeController } from './presentation/like.controller';
@@ -11,9 +11,16 @@ import { Interview } from './infrastructure/db/entity/interview.entity';
 import { SubCategory } from './infrastructure/db/entity/sub-category.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { InterviewRepository } from './infrastructure/db/repository/interview.repository';
+import { Like } from './infrastructure/db/entity/like.entity';
+import { AuthModule } from '../auth/auth.module';
+import { UserModule } from '../user/user.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Interview, SubCategory])],
+  imports: [
+    TypeOrmModule.forFeature([Interview, SubCategory, Like]),
+    AuthModule,
+    UserModule,
+  ],
   controllers: [
     QuizController,
     LikeController,
@@ -25,6 +32,7 @@ import { InterviewRepository } from './infrastructure/db/repository/interview.re
     LikeService,
     CategoryService,
     InterviewService,
+    Logger,
     {
       provide: 'IInterviewRepository',
       useClass: InterviewRepository,

--- a/src/modules/user/application/user.service.ts
+++ b/src/modules/user/application/user.service.ts
@@ -37,7 +37,7 @@ export class UserService {
     return await this.userRepository.save(user);
   }
 
-  async checkUserIsAdmin(id: string) {
+  async checkUserIsAdmin(id: number) {
     const user = await this.userRepository.findOneBy({ id });
     return user.role === Role.ADMIN;
   }

--- a/src/modules/user/infrastructure/db/entity/user.entity.ts
+++ b/src/modules/user/infrastructure/db/entity/user.entity.ts
@@ -13,8 +13,8 @@ import { QuizAttempt } from 'src/modules/quiz/infrastructure/db/entity/quiz-atte
 
 @Entity()
 export class User {
-  @PrimaryGeneratedColumn('uuid')
-  id: string;
+  @PrimaryGeneratedColumn()
+  id: number;
 
   @Column({ unique: true })
   platformId: string;


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
인터뷰와 관련된 좋아요 기능을 추가하고, 인터뷰 조회 시 사용자의 좋아요 상태를 함께 반환하도록 개선합니다.
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

### 좋아요 엔티티 및 관계 설정
- 좋아요 기능을 위한 엔티티를 추가하고, 인터뷰 엔티티와의 관계를 설정하였습니다.

### 좋아요 토글 기능 구현
- 좋아요 추가/삭제를 위한 API 엔드포인트를 추가하고, 서비스 로직을 구현하였습니다.


### 인터뷰 조회 시 좋아요 상태 포함
- 인터뷰 상세 조회 시 사용자의 좋아요 상태를 함께 반환하도록 수정하였습니다.

### 그 외 변경 사항
- JwtAuthGuard를 리팩토링하여 Public 라우트에서도 토큰 검증을 수행하도록 개선
    -  비로그인/로그인 상태 모두 접근 가능하게 하면서 토큰을 토대로 유저 정보를 읽기 위함.

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #32 

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->
좋아요 토글 응답
```
{
  "isLiked": false
}
```
인터뷰 조회 시 좋아요 상태 포함 - 인증된 상태에서의 응답.
```
{
  "id": 1,
  "question": "질문",
  "answer": "답변",
  "keywords": [
    "키워드1",
    "키워드2"
  ],
  "subCategory": {
    "id": 13,
    "name": "NETWORK",
    "main_category": "COMMON"
  },
  "createdAt": "2024-12-05T07:12:40.599Z",
  "isLiked": false
}
```
인증되지 않은 상태에서는 isLiked 필드가 제거된 원래의 응답이 반환됩니다.
클라이언트 측에서 로그인 하지 않은 사용자가 좋아요를 클릭시, 좋아요 토글 API를 호출 하는 것이 아닌, 로그인을 유도하는 것이 요구됩니다.
