### PR TITLE
feat: 닉네임 랜덤 생성 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "typeorm": "^0.3.20",
+    "uuid": "^11.0.3",
     "winston": "^3.17.0"
   },
   "devDependencies": {
@@ -53,6 +54,7 @@
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",
     "@types/supertest": "^6.0.0",
+    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "cross-env": "^7.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,9 @@ importers:
       typeorm:
         specifier: ^0.3.20
         version: 0.3.20(pg@8.13.1)(ts-node@10.9.2(@types/node@20.17.6)(typescript@5.6.3))
+      uuid:
+        specifier: ^11.0.3
+        version: 11.0.3
       winston:
         specifier: ^3.17.0
         version: 3.17.0
@@ -96,6 +99,9 @@ importers:
       '@types/supertest':
         specifier: ^6.0.0
         version: 6.0.2
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.0.0
         version: 8.14.0(@typescript-eslint/parser@8.14.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)
@@ -763,6 +769,9 @@ packages:
 
   '@types/triple-beam@1.3.5':
     resolution: {integrity: sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/validator@13.12.2':
     resolution: {integrity: sha512-6SlHBzUW8Jhf3liqrGGXyTJSIFe4nqlJ5A5KaMZ2l/vbM3Wh3KSybots/wfWVzNLK4D1NZluDlSQIbIEPx6oyA==}
@@ -3084,6 +3093,10 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@11.0.3:
+    resolution: {integrity: sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==}
+    hasBin: true
+
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     hasBin: true
@@ -4015,6 +4028,8 @@ snapshots:
       '@types/superagent': 8.1.9
 
   '@types/triple-beam@1.3.5': {}
+
+  '@types/uuid@10.0.0': {}
 
   '@types/validator@13.12.2': {}
 
@@ -6537,6 +6552,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuid@11.0.3: {}
 
   uuid@9.0.1: {}
 

--- a/src/modules/quiz/domain/default-nickname-policy.ts
+++ b/src/modules/quiz/domain/default-nickname-policy.ts
@@ -1,0 +1,19 @@
+// src/user/domain/default-nickname-policy.ts
+
+import { v4 as uuidv4 } from 'uuid';
+
+export class DefaultNicknamePolicy {
+  private static readonly RANDOM_LENGTH = 8;
+  private static readonly PREFIX = 'MATE';
+
+  // 랜덤 닉네임 생성 메서드
+  public static generateRandomString(): string {
+    const randomString = this.generateSubStringUUID();
+    return this.PREFIX + randomString;
+  }
+
+  // UUID 기반 서브스트링 생성 메서드
+  private static generateSubStringUUID(): string {
+    return uuidv4().replace(/-/g, '').substring(0, this.RANDOM_LENGTH);
+  }
+}

--- a/src/modules/user/application/user.service.ts
+++ b/src/modules/user/application/user.service.ts
@@ -5,6 +5,7 @@ import { Repository } from 'typeorm';
 import { Provider } from '../domain/provider.enum';
 import { KakaoUser } from '../../auth/domain/kakao-user.type';
 import { Role } from '../domain/role.enum';
+import { DefaultNicknamePolicy } from 'src/modules/quiz/domain/default-nickname-policy';
 @Injectable()
 export class UserService {
   constructor(
@@ -29,8 +30,7 @@ export class UserService {
   async createUser(kakaoUser: KakaoUser) {
     const user = new User();
 
-    // TODO : 랜던 닉네임으로 변경
-    user.nickname = kakaoUser.nickname;
+    user.nickname = DefaultNicknamePolicy.generateRandomString();
     user.profile_image = kakaoUser.profile_image;
     user.platformId = kakaoUser.kakaoId;
     user.provider = Provider.KAKAO;


### PR DESCRIPTION
## 📝 개요

<!-- 이 PR의 목적과 관련된 정보를 간략히 설명합니다. -->

```markdown
회원가입시 uuid를 기반으로 랜덤 닉네임을 생성하는 기능을 추가했습니다.
`MATE${8자리uuid}`의 형식으로 생성됩니다.
```

## ✨ 변경 사항

<!-- 코드나 기능의 주요 변경 사항을 설명 -->

- ✨ uuid 패키지 추가
- ✨ 닉네임 랜덤 생성 기능 추가

## 🔗 관련 이슈

<!-- 이 PR과 관련된 이슈 번호를 연결 (없으면 생략)) -->

- closed #38 
- resolved

## ℹ️ 참고 사항

<!-- 리뷰어가 알 필요가 있는 추가 정보나 문서, 참고 링크를 포함 -->

- 참고 1
- 참고 2
